### PR TITLE
Improve wiki generation reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Smart Analysis**: AI-powered understanding of code structure and relationships
 - **Beautiful Diagrams**: Automatic Mermaid diagrams to visualize architecture and data flow
 - **Easy Navigation**: Simple, intuitive interface to explore the wiki
+- **Live Page Generation**: Watch pages publish in real time with automatic retries for any failed attempts
 - **Ask Feature**: Chat with your repository using RAG-powered AI to get accurate answers
 - **DeepResearch**: Multi-turn research process that thoroughly investigates complex topics
 - **Multiple Model Providers**: Support for Google Gemini, OpenAI, OpenRouter, and local Ollama models


### PR DESCRIPTION
## Summary
- add resilient page generation queue with automatic retries and granular status tracking
- surface real-time progress, failure feedback, and live page availability in the repository wiki UI
- document live page generation capability in the feature list

## Testing
- npm run lint *(warns about existing dependency omissions in src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e265d444848326a528c8ca2447b6ed